### PR TITLE
Add --disable-plugins option

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,20 +27,23 @@ This will also install [locust](https://github.com/locustio/locust/) and [locust
 
 ```
 > har2locust --help
-usage: har2locust [-h] [-t TEMPLATE] [--plugins PLUGINS] [--resource-types RESOURCE_TYPES]
-                  [--version] [--loglevel LOGLEVEL]
+usage: har2locust [-h] [-t TEMPLATE] [--plugins PLUGINS] [--disable-plugins DISABLE_PLUGINS]
+                  [--resource-types RESOURCE_TYPES] [--version] [--loglevel LOGLEVEL]
                   input
 
 positional arguments:
   input                 har input file
 
-options:
+optional arguments:
   -h, --help            show this help message and exit
   -t TEMPLATE, --template TEMPLATE
                         jinja2 template used to generate locustfile. Defaults to locust.jinja2. Will
                         check current directory/relative paths first and har2locust built-ins second
   --plugins PLUGINS     Comma separated list of extra python files to source, containing decorated
                         methods for processing the har file.
+  --disable-plugins DISABLE_PLUGINS
+                        Temporarily disable default plugins. Specified by comma separated list of
+                        default plugin python files to source.
   --resource-types RESOURCE_TYPES
                         Commas separated list of resource types to be included in the locustfile.
                         Supported type are `xhr`, `script`, `stylesheet`, `image`, `font`,
@@ -48,7 +51,8 @@ options:
   --version, -V         show program's version number and exit
   --loglevel LOGLEVEL, -L LOGLEVEL
 
-Example usage: har2locust myrecording.har > locustfile
+Example usages: har2locust myrecording.har myplugin1.py > locustfile
+                har2locust --disable-plugins=rest.py myrecording.har myplugin1.py > locustfile
 
 Parameters can also be set using environment variables or config files (har2locust.conf
 or ~/.har2locust.conf) For details, see https://goo.gl/R74nmi

--- a/har2locust/__main__.py
+++ b/har2locust/__main__.py
@@ -14,7 +14,8 @@ from .plugin import entriesprocessor, entriesprocessor_with_args, astprocessor, 
 def __main__(arguments=None):
     args = get_parser().parse_args(arguments)
     logging.basicConfig(level=args.loglevel.upper())
-    load_plugins(args.plugins.split(",") if args.plugins else [])
+    load_plugins(args.plugins.split(",") if args.plugins else [],
+                 args.disable_plugins.split(",") if args.disable_plugins else [])
     har_path = pathlib.Path(args.input)
     name = har_path.stem.replace("-", "_").replace(".", "_")  # build class name from filename
     with open(har_path, encoding="utf8") as f:
@@ -27,11 +28,12 @@ def __main__(arguments=None):
     print(py)
 
 
-def load_plugins(plugins: list[str] = []):
+def load_plugins(plugins: list[str] = [], disable_plugins: list[str] = []):
     package_root_dir = pathlib.Path(__file__).parents[1]
     plugin_dir = package_root_dir / "har2locust/default_plugins"
     logging.debug(f"loading default plugins from {plugin_dir}")
-    default_plugins = [str(d.relative_to(package_root_dir)) for d in plugin_dir.glob("*.py")]
+    default_plugins = [str(d.relative_to(package_root_dir)) for d in plugin_dir.glob("*.py")
+                       if d.name not in disable_plugins]
     default_and_extra_plugins = default_plugins + plugins
     sys.path.append(os.path.curdir)  # accept plugins by relative path
     for plugin in default_and_extra_plugins:

--- a/har2locust/argument_parser.py
+++ b/har2locust/argument_parser.py
@@ -8,7 +8,8 @@ DEFAULT_CONFIG_FILES = ["~/.har2locust.conf", "har2locust.conf"]
 
 def get_parser() -> configargparse.ArgumentParser:
     parser = configargparse.ArgumentParser(
-        epilog="""Example usage: har2locust myrecording.har myplugin1.py > locustfile
+        epilog="""Example usages: har2locust myrecording.har myplugin1.py > locustfile
+                                  har2locust --disable-plugins=rest.py myrecording.har myplugin1.py > locustfile
 
 Parameters can also be set using environment variables or config files (har2locust.conf 
 or ~/.har2locust.conf) For details, see https://goo.gl/R74nmi""",
@@ -36,6 +37,12 @@ or ~/.har2locust.conf) For details, see https://goo.gl/R74nmi""",
         type=str,
         default="",
         help="Comma separated list of extra python files to source, containing decorated methods for processing the har file.",
+    )
+    parser.add_argument(
+        "--disable-plugins",
+        type=str,
+        default="",
+        help="Temporarily disable default plugins. Specified by comma separated list of default plugin python files to source.",
     )
     parser.add_argument(
         "--resource-types",


### PR DESCRIPTION
This option to disable any default plugins.
e.g. "rest.py" enforces the RestUser class, so you can use it if you want to generate the locustfile in another class.

