### PR TITLE
Add valid class name generation

### DIFF
--- a/tests/test_har2locust.py
+++ b/tests/test_har2locust.py
@@ -6,7 +6,7 @@ import subprocess
 
 import pytest
 
-from har2locust.__main__ import __main__
+from har2locust.__main__ import __main__, generate_class_name
 
 inputs_dir = pathlib.Path(__file__).parents[0] / "inputs"
 outputs_dir = pathlib.Path(__file__).parents[0] / "outputs"
@@ -186,3 +186,9 @@ def test_locust_run():
     _, stderr = proc.communicate()
     assert proc.returncode == 0, f"Bad return code {proc.returncode}, stderr: {stderr}"
     assert "--run-time limit reached" in stderr, stderr
+
+
+def test_generate_class_name_with_invalid_characters():
+    file_name = "0invalid(characters)"
+    generated_name = generate_class_name(file_name)
+    assert generated_name == "_invalid_characters_"


### PR DESCRIPTION
Not as trivial as I thought it'd be. Taking the definition in https://docs.python.org/3.8/reference/lexical_analysis.html#identifiers, the new code replaces any invalid character with an underscore.

Only added a simple test to the same file as the rest, I can add more if needed.

Fixes #14 